### PR TITLE
Adds TrafficControl and TrafficLegendControl

### DIFF
--- a/__mocks__/azure-maps-control.js
+++ b/__mocks__/azure-maps-control.js
@@ -64,7 +64,9 @@ module.exports = {
     CompassControl: jest.fn(() => ({ compassOption: 'option' })),
     PitchControl: jest.fn(() => ({ pitchOption: 'option' })),
     StyleControl: jest.fn(() => ({ styleOption: 'option' })),
-    ZoomControl: jest.fn(() => ({ zoomOption: 'option' }))
+    ZoomControl: jest.fn(() => ({ zoomOption: 'option' })),
+    TrafficControl: jest.fn(() => ({ trafficOption: 'option' })),
+    TrafficLegendControl: jest.fn(() => ({ trafficLegendOption: 'option' }))
   },
   layer: {
     ImageLayer: jest.fn((options, id) => ({ layer: 'ImageLayer', options, id })),

--- a/src/components/AzureMap/useCreateMapControl.test.tsx
+++ b/src/components/AzureMap/useCreateMapControl.test.tsx
@@ -80,6 +80,16 @@ describe('Control hooks', () => {
       expect(createdControl).toEqual({ compassOption: 'option' })
     })
 
+    it('should return TrafficControl if type equal TrafficControl', () => {
+      const createdControl = createControl('TrafficControl', {})
+      expect(createdControl).toEqual({ trafficOption: 'option' })
+    })
+
+    it('should return TrafficLegendControl if type equal TrafficLegendControl', () => {
+      const createdControl = createControl('TrafficLegendControl', {})
+      expect(createdControl).toEqual({ trafficLegendOption: 'option' })
+    })
+
     it('should return undefined if there is no control with type', () => {
       const createdControl = createControl('SomeOtherType', {})
       expect(createdControl).toEqual(undefined)

--- a/src/components/AzureMap/useCreateMapControls.tsx
+++ b/src/components/AzureMap/useCreateMapControls.tsx
@@ -50,3 +50,4 @@ export const useCreateMapCustomControls = (
     mapRef.controls.add(control, controlOptions)
   })
 }
+

--- a/src/components/AzureMap/useCreateMapControls.tsx
+++ b/src/components/AzureMap/useCreateMapControls.tsx
@@ -4,6 +4,7 @@ import atlas, {
   ControlOptions,
   PitchControlOptions,
   StyleControlOptions,
+  TrafficControlOptions,
   ZoomControlOptions
 } from 'azure-maps-control'
 
@@ -12,10 +13,10 @@ import atlas, {
 export const useCreateMapControls = (mapRef: MapType, controls: IAzureMapControls[]) => {
   controls.forEach((control: IAzureMapControls) => {
     const { controlName, options, controlOptions } = control
-    mapRef.controls.add(
-      createControl(controlName, controlOptions) as atlas.ControlBase,
-      options as ControlOptions
-    )
+      mapRef.controls.add(
+        createControl(controlName, controlOptions) as atlas.ControlBase,
+        options as ControlOptions
+      )
   })
 }
 
@@ -32,6 +33,10 @@ export const createControl = (
       return new atlas.control.StyleControl(options as StyleControlOptions)
     case 'ZoomControl':
       return new atlas.control.ZoomControl(options as ZoomControlOptions)
+    case 'TrafficControl':
+      return new atlas.control.TrafficControl(options as TrafficControlOptions)
+    case 'TrafficLegendControl':
+      return new atlas.control.TrafficLegendControl()
     default:
       console.warn('Check the type and passed props properties or try CustomControl')
   }


### PR DESCRIPTION
adds built-in TrafficControl and TrafficLegendControl described in [Add Traffic Controls](https://docs.microsoft.com/en-us/azure////azure-maps/map-show-traffic#add-traffic-controls).

#### Additional Notes
There exist an issue for now in TrafficControl when `{isActive: true}` is passed inside `TrafficControlOptions` described at: [Traffic control option isActive doesn't work when control is added in map ready handler](https://docs.microsoft.com/en-us/answers/questions/347142/bug-report-traffic-control-option-isactive-doesn39.html)