### PR TITLE
fix: eslint errors

### DIFF
--- a/src/components/AzureMap/AzureMap.test.tsx
+++ b/src/components/AzureMap/AzureMap.test.tsx
@@ -4,15 +4,15 @@ import { AzureMapsContext } from '../../contexts/AzureMapContext'
 import AzureMap from './AzureMap'
 import { Map } from 'azure-maps-control'
 import { IAzureMap, IAzureMapsContextProps } from '../../types'
-import { useCreateImageSprites } from './useCreateSprites'
-import { useCreateMapCustomControls, useCreateMapControls } from './useCreateMapControls'
+import { createImageSprites } from './useCreateSprites'
+import { createMapCustomControls, createMapControls } from './useCreateMapControls'
 
 const LoaderComponent = () => <div>Loader</div>
 
 jest.mock('./useCreateMapControls', () => {
   return {
-    useCreateMapCustomControls: jest.fn(),
-    useCreateMapControls: jest.fn()
+    createMapCustomControls: jest.fn(),
+    createMapControls: jest.fn()
   }
 })
 
@@ -108,7 +108,7 @@ describe('AzureMap Component', () => {
     expect(mapContextProps.removeMapRef).toHaveBeenCalled()
   })
 
-  it('should call useCreateImageSprites if imageSprites is not falsy', () => {
+  it('should call createImageSprites if imageSprites is not falsy', () => {
     const mapRef = new Map('fake', {})
     render(
       wrapWithAzureMapContext(
@@ -116,17 +116,17 @@ describe('AzureMap Component', () => {
         { imageSprites: [{ id: 'some_fake_id' }] }
       )
     )
-    expect(useCreateImageSprites).toHaveBeenCalled()
+    expect(createImageSprites).toHaveBeenCalled()
   })
 
-  it('should call useCreateMapControls if controls is not falsy', () => {
+  it('should call createMapControls if controls is not falsy', () => {
     const mapRef = new Map('fake', {})
     const fakeControls = [{ controlName: 'fake_control_name' }]
     render(wrapWithAzureMapContext({ ...mapContextProps, mapRef }, { controls: fakeControls }))
-    expect(useCreateMapControls).toHaveBeenCalledWith(expect.any(Object), fakeControls)
+    expect(createMapControls).toHaveBeenCalledWith(expect.any(Object), fakeControls)
   })
 
-  it('should call useCreateMapCustomControls if customControls is not falsy', () => {
+  it('should call createMapCustomControls if customControls is not falsy', () => {
     const mapRef = new Map('fake', {})
     const customControls = [
       {
@@ -142,7 +142,7 @@ describe('AzureMap Component', () => {
         }
       )
     )
-    expect(useCreateMapCustomControls).toHaveBeenCalledWith(expect.any(Object), customControls)
+    expect(createMapCustomControls).toHaveBeenCalledWith(expect.any(Object), customControls)
   })
 
   it('should setTraffic on initial props', () => {

--- a/src/components/AzureMap/AzureMap.tsx
+++ b/src/components/AzureMap/AzureMap.tsx
@@ -6,8 +6,8 @@ import { Guid } from 'guid-typescript'
 import 'azure-maps-control/dist/atlas.min.css'
 import 'mapbox-gl/src/css/mapbox-gl.css'
 import { useCheckRef } from '../../hooks/useCheckRef'
-import { useCreateImageSprites } from './useCreateSprites'
-import { useCreateMapControls, useCreateMapCustomControls } from './useCreateMapControls'
+import { createImageSprites } from './useCreateSprites'
+import { createMapControls, createMapCustomControls } from './useCreateMapControls'
 
 const AzureMap = memo(
   ({
@@ -64,13 +64,13 @@ const AzureMap = memo(
     useCheckRef<MapType, MapType>(mapRef, mapRef, mref => {
       mref.events.add('ready', () => {
         if (imageSprites) {
-          useCreateImageSprites(mref, imageSprites)
+          createImageSprites(mref, imageSprites)
         }
         if (controls) {
-          useCreateMapControls(mref, controls)
+          createMapControls(mref, controls)
         }
         if (customControls) {
-          useCreateMapCustomControls(mref, customControls)
+          createMapCustomControls(mref, customControls)
         }
         if (trafficOptions) {
           mref.setTraffic(trafficOptions)

--- a/src/components/AzureMap/useCreateMapControl.test.tsx
+++ b/src/components/AzureMap/useCreateMapControl.test.tsx
@@ -1,8 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks'
 import {
   createControl,
-  useCreateMapControls,
-  useCreateMapCustomControls
+  createMapControls,
+  createMapCustomControls
 } from './useCreateMapControls'
 import { Map } from 'azure-maps-control'
 import { IAzureMapControls, IAzureCustomControls } from '../../types'
@@ -34,7 +34,7 @@ describe('Control hooks', () => {
     it('should create two map controls and call proper method', () => {
       const mockMap = new Map('#fake-container', {})
       mockMap.controls.add = jest.fn()
-      renderHook(() => useCreateMapControls(mockMap, fakeDefaultControls))
+      renderHook(() => createMapControls(mockMap, fakeDefaultControls))
       expect(mockMap.controls.add).toHaveBeenCalledWith(
         { compassOption: 'option' },
         fakeDefaultControls[0].options
@@ -46,11 +46,11 @@ describe('Control hooks', () => {
     })
   })
 
-  describe('useCreateMapCustomControls tests', () => {
+  describe('createMapCustomControls tests', () => {
     it('should create custom map controls and call proper method', () => {
       const mockMap = new Map('#fake-container', {})
       mockMap.controls.add = jest.fn()
-      renderHook(() => useCreateMapCustomControls(mockMap, fakeCustomControlls))
+      renderHook(() => createMapCustomControls(mockMap, fakeCustomControlls))
       expect(mockMap.controls.add).toHaveBeenCalledTimes(1)
       expect(mockMap.controls.add).toHaveBeenCalledWith(
         fakeCustomControlls[0].control,

--- a/src/components/AzureMap/useCreateMapControls.tsx
+++ b/src/components/AzureMap/useCreateMapControls.tsx
@@ -9,7 +9,7 @@ import atlas, {
 
 
 
-export const useCreateMapControls = (mapRef: MapType, controls: IAzureMapControls[]) => {
+export const createMapControls = (mapRef: MapType, controls: IAzureMapControls[]) => {
   controls.forEach((control: IAzureMapControls) => {
     const { controlName, options, controlOptions } = control
     mapRef.controls.add(
@@ -37,7 +37,7 @@ export const createControl = (
   }
 }
 
-export const useCreateMapCustomControls = (
+export const createMapCustomControls = (
   mapRef: MapType,
   customControls: IAzureCustomControls[]
 ) => {

--- a/src/components/AzureMap/useCreateSprites.test.tsx
+++ b/src/components/AzureMap/useCreateSprites.test.tsx
@@ -1,8 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useCreateImageSprites } from './useCreateSprites'
+import { createImageSprites } from './useCreateSprites'
 import { Map } from 'azure-maps-control'
 
-describe('useCreateImageSprites tests', () => {
+describe('createImageSprites tests', () => {
   it('should create image sprintes with icon field and call proper methods', async () => {
     const mockMap = new Map('#fake-container', {})
     const fakeImageSprite = {
@@ -13,7 +13,7 @@ describe('useCreateImageSprites tests', () => {
       secondaryColor: 'color',
       scale: 1
     }
-    const { result } = renderHook(() => useCreateImageSprites(mockMap, [fakeImageSprite]))
+    const { result } = renderHook(() => createImageSprites(mockMap, [fakeImageSprite]))
     await result.current
     expect(mockMap.imageSprite.add).toHaveBeenCalledWith('id', 'icon')
     expect(mockMap.imageSprite.createFromTemplate).toHaveBeenCalledWith(
@@ -34,7 +34,7 @@ describe('useCreateImageSprites tests', () => {
       secondaryColor: 'color',
       scale: 1
     }
-    const { result } = renderHook(() => useCreateImageSprites(mockMap, [fakeImageSprite]))
+    const { result } = renderHook(() => createImageSprites(mockMap, [fakeImageSprite]))
     await result.current
     expect(mockMap.imageSprite.add).not.toHaveBeenCalled()
     expect(mockMap.imageSprite.createFromTemplate).toHaveBeenCalledWith(
@@ -54,7 +54,7 @@ describe('useCreateImageSprites tests', () => {
       secondaryColor: 'color',
       scale: 1
     }
-    const { result } = renderHook(() => useCreateImageSprites(mockMap, [fakeImageSprite]))
+    const { result } = renderHook(() => createImageSprites(mockMap, [fakeImageSprite]))
     await result.current
     expect(mockMap.imageSprite.add).not.toHaveBeenCalled()
     expect(mockMap.imageSprite.createFromTemplate).toHaveBeenCalledWith(

--- a/src/components/AzureMap/useCreateSprites.tsx
+++ b/src/components/AzureMap/useCreateSprites.tsx
@@ -1,6 +1,6 @@
 import { IAzureMapImageSprite, MapType } from '../../types'
 
-export const useCreateImageSprites = async (
+export const createImageSprites = async (
   mapRef: MapType,
   spriteArray: IAzureMapImageSprite[]
 ) => {

--- a/src/components/AzureMapFeature/AzureMapFeature.test.tsx
+++ b/src/components/AzureMapFeature/AzureMapFeature.test.tsx
@@ -9,7 +9,7 @@ import atlas from 'azure-maps-control'
 
 jest.mock('./useFeature')
 jest.mock('./useCreateAzureMapFeature.ts', () => ({
-  useCreateAzureMapFeature: () => ({})
+  createAzureMapFeature: () => ({})
 }))
 
 const mapRef = new Map('fake', {})

--- a/src/components/AzureMapFeature/AzureMapFeature.tsx
+++ b/src/components/AzureMapFeature/AzureMapFeature.tsx
@@ -3,7 +3,7 @@ import atlas from 'azure-maps-control'
 
 import { FeatureType, IAzureMapDataSourceProps, IAzureMapFeature, ShapeType } from '../../types'
 import { AzureMapDataSourceContext } from '../../contexts/AzureMapDataSourceContext'
-import { useCreateAzureMapFeature } from './useCreateAzureMapFeature'
+import { createAzureMapFeature } from './useCreateAzureMapFeature'
 import { useFeature } from './useFeature'
 
 const AzureMapFeature = memo((props: IAzureMapFeature) => {
@@ -15,7 +15,7 @@ const AzureMapFeature = memo((props: IAzureMapFeature) => {
   useFeature(props, dataSourceRef, shapeRef, featureRef)
 
   useEffect(() => {
-    const featureSource: atlas.data.Geometry | undefined = useCreateAzureMapFeature(props)
+    const featureSource: atlas.data.Geometry | undefined = createAzureMapFeature(props)
 
     if ((!featureRef || !shapeRef) && featureSource) {
       switch (variant) {

--- a/src/components/AzureMapFeature/useCreateAzureMapFeature.test.tsx
+++ b/src/components/AzureMapFeature/useCreateAzureMapFeature.test.tsx
@@ -1,6 +1,6 @@
 import atlas from 'azure-maps-control'
 import { IAzureMapFeature } from '../../types'
-import { useCreateAzureMapFeature } from './useCreateAzureMapFeature'
+import { createAzureMapFeature } from './useCreateAzureMapFeature'
 
 const fakeCoordinate: atlas.data.Position = new atlas.data.Position(10, 10)
 const fakeCoordinates: atlas.data.Position[] = [
@@ -20,13 +20,13 @@ const fakeBbox: atlas.data.BoundingBox = new atlas.data.BoundingBox(
 )
 
 describe('AzureMapFeature hooks', () => {
-  describe('useCreateAzureMapFeature tests', () => {
+  describe('createAzureMapFeature tests', () => {
     it('should return Point if type equal Point', () => {
       const pointProps: IAzureMapFeature = {
         type: 'Point',
         coordinate: fakeCoordinate
       }
-      const createPoint = useCreateAzureMapFeature(pointProps)
+      const createPoint = createAzureMapFeature(pointProps)
       expect(createPoint).toEqual({ coords: [10, 10], type: 'Point' })
     })
     it('should return MultiPoint if type equal MultiPoint', () => {
@@ -35,7 +35,7 @@ describe('AzureMapFeature hooks', () => {
         coordinates: fakeCoordinates,
         bbox: fakeBbox
       }
-      const createMultiPoint = useCreateAzureMapFeature(multiPointProps)
+      const createMultiPoint = createAzureMapFeature(multiPointProps)
       expect(createMultiPoint).toEqual({
         bbox: [
           [10, 10],
@@ -54,7 +54,7 @@ describe('AzureMapFeature hooks', () => {
         coordinates: fakeCoordinates,
         bbox: fakeBbox
       }
-      const createLineString = useCreateAzureMapFeature(lineStringProps)
+      const createLineString = createAzureMapFeature(lineStringProps)
       expect(createLineString).toEqual({
         bbox: [
           [10, 10],
@@ -73,7 +73,7 @@ describe('AzureMapFeature hooks', () => {
         multipleCoordinates: fakeMultipleCoordinates,
         bbox: fakeBbox
       }
-      const createMultiLineStringProps = useCreateAzureMapFeature(multiLineStringProps)
+      const createMultiLineStringProps = createAzureMapFeature(multiLineStringProps)
       expect(createMultiLineStringProps).toEqual({
         bbox: [
           [10, 10],
@@ -89,7 +89,7 @@ describe('AzureMapFeature hooks', () => {
         coordinates: fakeCoordinates,
         bbox: fakeBbox
       }
-      const createLineString = useCreateAzureMapFeature(lineStringProps)
+      const createLineString = createAzureMapFeature(lineStringProps)
       expect(createLineString).toEqual({
         bbox: [
           [10, 10],
@@ -108,7 +108,7 @@ describe('AzureMapFeature hooks', () => {
         multipleDimensionCoordinates: fakeMultipleDimensionCoordinates,
         bbox: fakeBbox
       }
-      const createMultiPolygon = useCreateAzureMapFeature(multiPolygonProps)
+      const createMultiPolygon = createAzureMapFeature(multiPolygonProps)
       expect(createMultiPolygon).toEqual({
         bbox: [
           [10, 10],

--- a/src/components/AzureMapFeature/useCreateAzureMapFeature.ts
+++ b/src/components/AzureMapFeature/useCreateAzureMapFeature.ts
@@ -1,7 +1,7 @@
 import { IAzureMapFeature } from '../../types'
 import atlas from 'azure-maps-control'
 
-export const useCreateAzureMapFeature = ({
+export const createAzureMapFeature = ({
   type,
   coordinate,
   coordinates,

--- a/src/components/AzureMapMarkers/AzureMapHtmlMarker/AzureMapHtmlMarker.test.tsx
+++ b/src/components/AzureMapMarkers/AzureMapHtmlMarker/AzureMapHtmlMarker.test.tsx
@@ -75,7 +75,7 @@ describe('AzureMaphtmlMarker tests', () => {
       expect(markerRef.setOptions).toHaveBeenCalledWith({ option: 'option' })
     })
 
-    it('should call setOptions on markerRef', () => {
+    it('should call setOptions on markerRef when marketContent prop is passed', () => {
       markerRef.setOptions = jest.fn()
       render(wrapWithAzureMapContext({ markerContent: <div /> }))
       expect(markerRef.setOptions).toHaveBeenCalledWith({ htmlContent: '<div></div>' })

--- a/src/components/AzureMapPopup/AzureMapPopup.test.tsx
+++ b/src/components/AzureMapPopup/AzureMapPopup.test.tsx
@@ -68,7 +68,7 @@ describe('AzureMapPopup tests', () => {
     expect(popupRef.open).toHaveBeenCalledWith(mapRef)
   })
 
-  it('should ropen popup when isVisible is true and isOpen returns false', () => {
+  it('should close popup when isVisible is false and isOpen returns true', () => {
     popupRef.isOpen = jest.fn(() => true)
     mapRef.popups.getPopups = jest.fn(() => [popupRef])
     render(

--- a/src/components/AzureMapPopup/AzureMapPopup.test.tsx
+++ b/src/components/AzureMapPopup/AzureMapPopup.test.tsx
@@ -57,7 +57,7 @@ describe('AzureMapPopup tests', () => {
     expect(mapRef.popups.remove).toHaveBeenCalled()
   })
 
-  it('should ropen popup when isVisible is true and isOpen returns false', () => {
+  it('should open popup when isVisible is true and isOpen returns false', () => {
     popupRef.isOpen = jest.fn(() => false)
     render(
       wrapWithAzureMapContext({

--- a/src/hooks/constructLayer.test.tsx
+++ b/src/hooks/constructLayer.test.tsx
@@ -108,7 +108,7 @@ describe('constructLayer', () => {
     )
     expect(createLayer).toEqual({ layer: 'TileLayer', options: {}, id: 'TileLayerId' })
   })
-  it('should return TileLayer props if type equal to TileLayer', () => {
+  it('should return BubbleLayer props if type equal to BubbleLayer', () => {
     const createLayer = constructLayer(
       {
         id: 'BubbleLayerId',


### PR DESCRIPTION
Fixes `eslint` errors by:

* dropping use prefix from functions that are not composed of react hooks
* fixing duplicated jest test titles